### PR TITLE
ruby: return error when license is brank

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 			}
 			result, confidence, err := new(licensecheck.Scanner).Scan(name, version, typ)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			fmt.Printf("Licnese: %s, Confidense: %d%%\n", result, int(confidence*100))
 			return nil

--- a/core/ruby/scanner.go
+++ b/core/ruby/scanner.go
@@ -40,7 +40,7 @@ func parseResponce(b []byte) (string, float64, error) {
 		return "", 0, shared.ErrNotFound
 	}
 
-	if license.Licenses == nil {
+	if len(license.Licenses) == 0 {
 		return "", 0, shared.ErrNotFound
 	}
 	return strings.Join(license.Licenses, ","), 1, nil


### PR DESCRIPTION
ex: https://rubygems.org/gems/capistrano-rails/versions/1.1.6

```
 go run cmd/main.go -t ruby -n capistrano-rails -v 1.1.6
Licnese: , Confidense: 100%
```
↓

```
 go run cmd/main.go -t ruby -n capistrano-rails -v 1.1.6
2022/03/23 12:32:11 no license info found
exit status 1
```